### PR TITLE
Handle dynamic frontend connection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pygame==2.5.2
+pyperclip==1.8.2

--- a/src/modules/network/network.py
+++ b/src/modules/network/network.py
@@ -13,20 +13,16 @@ class Network:
     def __init__(self):
         self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.client.settimeout(5.0)  # may raise socket.timeout exception
-        self.server = "10.0.0.137"  # WARNING: hardcode & need to be consistenet with server.py
-        self.port = 5555
-        self.server_addr = (self.server, self.port)
-        self.connect()
 
-    def connect(self):
-        try:
-            self.client.connect(self.server_addr)
-            if s.decode_connect_response(self.client.recv(2048)):
-                logger.info("Connection established.")
-            else:
-                logger.error("Connection failed to establish.")
-        except:
-            pass
+    def connect(self, ip: str):
+        logger.info("Connecting to %s", ip)
+        host, port = ip.split(":")
+        self.client.connect((host, int(port)))
+
+        if s.decode_connect_response(self.client.recv(2048)):
+            logger.info("Connection established.")
+        else:
+            logger.error("Connection failed to establish.")
 
     def send_name(self, name):
         try:
@@ -51,8 +47,3 @@ class Network:
 
     def finish_game(self, time):
         return
-
-
-# Testing
-n = Network()
-print(n.send_name("Toffoli"))

--- a/src/modules/scene/abstract_scene.py
+++ b/src/modules/scene/abstract_scene.py
@@ -1,10 +1,11 @@
 from abc import ABC, abstractmethod
 from pygame import Surface
 from ..state import PlayerState
+from ..network.network import Network
 
 
 class AbstractScene(ABC):
-    def __init__(self, screen: Surface, player_state: PlayerState, network: any):
+    def __init__(self, screen: Surface, player_state: PlayerState, network: Network):
         self.__screen = screen
         self.__player_state = player_state
         self.__network = network

--- a/src/modules/scene/entry_scene.py
+++ b/src/modules/scene/entry_scene.py
@@ -1,8 +1,71 @@
+import sys
+import pygame
+import pyperclip
 from .abstract_scene import AbstractScene
 from .scene_state import SceneState
+from .styles import STYLE
 
 
 class EntryScene(AbstractScene):
     def start_scene(self):
-        # TODO: Implement entry scene
-        return SceneState.PLAYER_QUESTION
+        clock = pygame.time.Clock()
+
+        ip = ""
+
+        active = False
+        textbox, textbox_border = self.__create_textbox()
+        while True:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit(0)
+
+                if event.type == pygame.MOUSEBUTTONDOWN:
+                    active = textbox.collidepoint(event.pos)
+
+                if event.type == pygame.KEYDOWN:
+                    if event.key == pygame.K_RETURN:
+                        self.get_network().connect(ip)
+                        return SceneState.PLAYER_QUESTION
+                    elif event.key == pygame.K_v and (event.mod & pygame.KMOD_CTRL or event.mod & pygame.KMOD_META):
+                        ip = pyperclip.paste()
+                    elif event.key == pygame.K_BACKSPACE:
+                        ip = ip[:-1]
+                    else:
+                        ip += event.unicode
+
+            self.get_screen().fill("white")
+
+            self.__create_prompt()
+
+            pygame.draw.rect(self.get_screen(), pygame.Color(
+                "#8489FBFF") if active else "black", textbox_border)
+            pygame.draw.rect(self.get_screen(), "white", textbox)
+
+            padding_x = 10
+            text_surface = STYLE["font"]["text"].render(ip, True, (0, 0, 0))
+            # TODO(nickbar01234) - Handle clip text
+            self.get_screen().blit(text_surface, (textbox.x + padding_x,
+                                                  textbox.y + textbox.height // 2 - 12))
+            pygame.display.flip()
+
+            clock.tick(STYLE["fps"])
+
+    def __create_prompt(self):
+        font = STYLE["font"]["title"]
+        text = font.render("Enter server IP address:", True, "black")
+        rect = text.get_rect()
+        rect.center = self.get_screen().get_rect().center
+        rect = rect.inflate(0, 256)
+        self.get_screen().blit(text, rect)
+
+    def __create_textbox(self):
+        border = 3
+        width, height = 512, 64
+        center_x, center_y = self.get_screen().get_rect().center
+        textbox_border = pygame.Rect(0, 0, width, height)
+        textbox_border.center = (center_x, center_y)
+        left_x, left_y = textbox_border.topleft
+        textbox = pygame.Rect(0, 0, width - border * 2, height - border * 2)
+        textbox.topleft = (left_x + border, left_y + border)
+        return textbox, textbox_border

--- a/src/modules/scene/styles.py
+++ b/src/modules/scene/styles.py
@@ -8,7 +8,7 @@ BASE = "./static/font"
 pygame.init()
 
 
-def font_builder(size: int, sty: Literal["default", "black", "bold", "extrabold"] = "default"):
+def font_builder(size: int, sty: Literal["default", "black", "bold", "extrabold"] = "black"):
     path = {
         "default": f"{BASE}/Montserrat-VariableFont_wght.ttf",
         "black": f"{BASE}/Montserrat-Black.ttf",
@@ -29,6 +29,7 @@ class StyleType(TypedDict):
     width: int
     height: int
     font: FontType
+    fps: int
 
 
 STYLE: StyleType = {
@@ -39,5 +40,6 @@ STYLE: StyleType = {
         "text": font_builder(16)
     },
     "width": 720,
-    "height": 1280
+    "height": 1280,
+    "fps": 60
 }

--- a/src/server.py
+++ b/src/server.py
@@ -1,9 +1,9 @@
+import logging
 import socket
 import threading
 import sys
 from modules import serializer as s
 
-import logging
 logger = logging.getLogger()
 logging.basicConfig(encoding='utf-8', level=logging.DEBUG)
 
@@ -28,7 +28,8 @@ class Server:
         server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         server_socket.bind(self.addr)
         server_socket.listen()
-        logger.info(f"Server started, listening on localhost:{self.addr}")
+        logger.info("Server started, listening on %s:%s",
+                    self.addr[0], self.addr[1])
 
         while True:
             player_socket, player_addr = server_socket.accept()
@@ -86,9 +87,6 @@ class Server:
 
 
 if __name__ == "__main__":
-    # Testing establishing the connection
-    # WARNING: hardcode
-    server_ip = "10.243.20.119"
-    # server = "10.243.75.99"
-    port = 5555
-    Server(server_ip, port).start()
+    IP = socket.gethostbyname(socket.gethostname())
+    PORT = 5555
+    Server(IP, PORT).start()


### PR DESCRIPTION
# Description

- On starting the frontend, prompt the players to enter the IP address of the server. This is less error-prone and more convenient when we're developing independently.
- On backend, the IP address is dynamically determined.
- I installed `pyperclip` for pasting IP address convinience.